### PR TITLE
[BUILD] - Updated base zk image to openjdk 14.0.2

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,9 +1,6 @@
 name: build-publish-docker-image
 
-on:
-  push:
-    tags:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:
@@ -12,8 +9,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get tag name
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF:10}
-      - uses: docker/build-push-action@v1
+        run: |
+          ref=${GITHUB_REF:10}
+          ref="${ref////-}"
+          echo $ref
+          echo ::set-output name=tag::$ref
+      - name: Build and push zookeeper-operator image
+        uses: docker/build-push-action@v1
         with:
           dockerfile: Dockerfile
           build_args: VERSION=${{ steps.vars.outputs.tag }},GIT_SHA=${{ github.sha }}
@@ -21,5 +23,17 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: adobe/zookeeper-operator
           tag_with_ref: true
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
           add_git_labels: true
+          always_pull: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Build and push zookeeper image
+        uses: docker/build-push-action@v1
+        with:
+          path: docker
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: adobe/zookeeper
+          tags: 3.6.1-${{ steps.vars.outputs.tag }}
+          add_git_labels: true
+          always_pull: true
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,16 +8,18 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM openjdk:11-jdk
+FROM openjdk:14.0.2-slim
 RUN mkdir /zu
 COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM zookeeper:3.6.1
+# use forked base zookeeper 3.6.1 docker image
+# that runs on openjdk-14.0.2 instead of openjdk-11
+FROM amuraru/zookeeper:3.6.1
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/
 
 RUN apt-get -q update && \
-    apt-get install -y dnsutils curl procps
+    apt-get install --no-install-recommends -y curl dnsutils procps


### PR DESCRIPTION
- use openjdk 14.0.2 as base image for zk (the same used in kafka docker image): see https://github.com/amuraru/zookeeper-docker/commit/f7601229341bdf41f4aa05e7be6f0282bafc38e9
- added github action step to build adobe/zookeeper docker image using the zk-operator startup scripts in this repo
