### PR TITLE
Use getent instead of nslookup for starting scripts

### DIFF
--- a/docker/bin/zookeeperFunctions.sh
+++ b/docker/bin/zookeeperFunctions.sh
@@ -19,8 +19,8 @@ function zkConfig() {
 function zkConnectionString() {
   # If the client service address is not yet available, then return localhost
   set +e
-  nslookup "${CLIENT_HOST}" 2>/dev/null 1>/dev/null
-  if [[ $? -eq 1 ]]; then
+  getent hosts "${CLIENT_HOST}" 2>/dev/null 1>/dev/null
+  if [[ $? -ne 0 ]]; then
     set -e
     echo "localhost:${CLIENT_PORT}"
   else

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -25,8 +25,8 @@ OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 # Check to see if zookeeper service answers
 if [[ "$OK" == "imok" ]]; then
   set +e
-  nslookup $DOMAIN
-  if [[ $? -eq 1 ]]; then
+  getent hosts $DOMAIN
+  if [[ $? -ne 0 ]]; then
     set -e
     echo "There is no active ensemble, skipping readiness probe..."
     exit 0

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -69,12 +69,12 @@ if [[ -n "$ENVOY_SIDECAR_STATUS" ]]; then
 fi
 set -e
 
-# Determine if there is a ensemble available to join by checking the service domain
+# Determine if there is an ensemble available to join by checking the service domain
 set +e
-nslookup $DOMAIN
-if [[ $? -eq 1 ]]; then
-  # If an nslookup of the headless service domain fails, then there is no
-  # active ensemble yet, but in certain cases nslookup of headless service
+getent hosts $DOMAIN  # This only performs a dns lookup
+if [[ $? -ne 0 ]]; then
+  # If dns lookup of the headless service domain fails, then there is no
+  # active ensemble yet, but in certain cases the dns lookup of headless service
   # takes a while to come up even if there is active ensemble
   ACTIVE_ENSEMBLE=false
   declare -i count=20
@@ -82,7 +82,7 @@ if [[ $? -eq 1 ]]; then
   do
     sleep 2
     ((count=count-1))
-    nslookup $DOMAIN
+    getent hosts $DOMAIN
     if [[ $? -eq 0 ]]; then
       ACTIVE_ENSEMBLE=true
       break

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -22,11 +22,14 @@ import (
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
 	// container
-	DefaultZkContainerRepository = "pravega/zookeeper"
+	//DefaultZkContainerRepository = "pravega/zookeeper"
+	DefaultZkContainerRepository = "cr.k8s.tubemogul.info/jinhuan/zookeeper"
+
+	//cr.k8s.tubemogul.info/jinhuan/zookeeper:v0.2.9-rc0-dirty
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "0.2.8"
+	DefaultZkContainerVersion = "latest"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -20,13 +20,13 @@ import (
 )
 
 const (
-	// Default images
-	//DefaultZkContainerRepository = "pravega/zookeeper"
-	//DefaultZkContainerVersion = "0.2.8"
+	// DefaultZkContainerRepository is the default docker repo for the zookeeper
+	// container
+	DefaultZkContainerRepository = "pravega/zookeeper"
 
-	// Image built by Adobe ad-cloud
-	DefaultZkContainerRepository = "cr.k8s.tubemogul.info/jinhuan/zookeeper"
-	DefaultZkContainerVersion = "v0.2.9"
+	// DefaultZkContainerVersion is the default tag used for for the zookeeper
+	// container
+	DefaultZkContainerVersion = "0.2.8"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -20,16 +20,13 @@ import (
 )
 
 const (
-	// DefaultZkContainerRepository is the default docker repo for the zookeeper
-	// container
+	// Default images
 	//DefaultZkContainerRepository = "pravega/zookeeper"
+	//DefaultZkContainerVersion = "0.2.8"
+
+	// Image built by Adobe ad-cloud
 	DefaultZkContainerRepository = "cr.k8s.tubemogul.info/jinhuan/zookeeper"
-
-	//cr.k8s.tubemogul.info/jinhuan/zookeeper:v0.2.9-rc0-dirty
-
-	// DefaultZkContainerVersion is the default tag used for for the zookeeper
-	// container
-	DefaultZkContainerVersion = "latest"
+	DefaultZkContainerVersion = "v0.2.9"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"


### PR DESCRIPTION
The nslookup only exit with status 0 with successful lookup of dns record for both forward and backward lookups. It would mean that the cluster's DNS setup has to support.

I would recommend that the lookup would only be a forward lookup. Something like getent host should work. I will submit a PR to fix that.

pravega#76