### PR TITLE
Make zookeeper node ids start from value grater than 1

### DIFF
--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -20,6 +20,9 @@ MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
 STATIC_CONFIG=/data/conf/zoo.cfg
 
+# used when zkid starts from value grater then 1, default 1
+OFFSET=${OFFSET:-1}
+
 OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 
 # Check to see if zookeeper service answers
@@ -44,7 +47,7 @@ if [[ "$OK" == "imok" ]]; then
         echo Failed to parse name and ordinal of Pod
         exit 1
     fi
-    MYID=$((ORD+1))
+    MYID=$(($ORD+$OFFSET))
     ONDISK_CONFIG=false
     if [ -f $MYID_FILE ]; then
       EXISTING_ID="`cat $DATA_DIR/myid`"

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -21,6 +21,9 @@ LOG4J_CONF=/conf/log4j-quiet.properties
 DYNCONFIG=$DATA_DIR/zoo.cfg.dynamic
 STATIC_CONFIG=/data/conf/zoo.cfg
 
+# used when zkid starts from value grater then 1, default 1
+OFFSET=${OFFSET:-1}
+
 # Extract resource name and this members ordinal value from pod hostname
 if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
     NAME=${BASH_REMATCH[1]}
@@ -30,7 +33,8 @@ else
     exit 1
 fi
 
-MYID=$((ORD+1))
+MYID=$(($ORD+$OFFSET))
+
 
 # Values for first startup
 WRITE_CONFIGURATION=true
@@ -114,7 +118,7 @@ fi
 if [[ "$WRITE_CONFIGURATION" == true ]]; then
   echo "Writing myid: $MYID to: $MYID_FILE."
   echo $MYID > $MYID_FILE
-  if [[ $MYID -eq 1 ]]; then
+  if [[ $MYID -eq $OFFSET ]]; then
     ROLE=participant
     echo Initial initialization of ordinal 0 pod, creating new config.
     ZKCONFIG=$(zkConfig)


### PR DESCRIPTION
### Change log description

There are use cases where zk node ids must start from a value grater than 1. This PR makes then configurable via pod environment variables.
