### PR TITLE
Core 46905- Send Ethos K8s Operators (ZK & Kafka) logs to Splunk

### DIFF
--- a/charts/zookeeper-operator/templates/fluent-bit-configmap.yaml
+++ b/charts/zookeeper-operator/templates/fluent-bit-configmap.yaml
@@ -1,0 +1,138 @@
+{{- if .Values.logForward.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.splunk.fluentBit.name }}-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper-operator.commonLabels" . | indent 4 }}
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+      Flush 1
+      Log_Level info
+      Daemon off
+      Parsers_File parsers.conf
+      HTTP_Server On
+      HTTP_Listen 0.0.0.0
+      HTTP_Port 2020
+      storage.path /var/fluent-bit/buffers
+      storage.backlog.mem_limit 10G
+    [INPUT]
+      Name tail
+      Parser ${CONTAINER_RUNTIME}
+      Path /logging-volume/*.log
+      Tag pod.local
+      Refresh_Interval 1
+      DB /var/fluent-bit/logs.db
+      Buffer_Max_Size 50M
+      storage.type filesystem
+    [FILTER]
+      Name modify
+      Match pod.*
+      Rename log message
+      Add index ${SPLUNK_INDEX}
+      Add host ${POD_NAME}
+      Add sourcetype ${SPLUNK_SOURCETYPE}
+      Add source ${SPLUNK_SOURCE}
+      Add namespace ${POD_NAMESPACE}
+      Add node_ip ${NODE_IP}
+      Add node_name ${NODE_NAME}
+      Add pod_ip ${POD_IP}
+      Add pod_name ${POD_NAME}
+      Add pod_uid ${POD_UID}
+    [FILTER]
+      Name nest
+      Match *
+      Operation nest
+      Wildcard message
+      Wildcard namespace
+      Wildcard node_ip
+      Wildcard node_name
+      Wildcard pod_ip
+      Wildcard pod_name
+      Wildcard pod_uid
+      Wildcard stream
+      Wildcard tags # CRI log tags
+      Nest_under event
+    [FILTER]
+      # Only the following keys are allowed in Splunk HEC payloads:
+      # - event
+      # - fields
+      # - host
+      # - index
+      # - source
+      # - sourcetype
+      # - time
+      # We drop the time key to allow Fluent Bit to correctly format the time
+      # key in Splunk HEC format.
+      # All other keys _must_ be dropped, or Splunk will reject the entire
+      # payload with an HTTP 400 error.
+      # https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/FormateventsforHTTPEventCollector
+      # https://docs.fluentbit.io/manual/filter/record_modifier#remove-fields-with-whitelist_key
+      Name record_modifier
+      Match *
+      Whitelist_key event
+      Whitelist_key fields
+      Whitelist_key host
+      Whitelist_key index
+      Whitelist_key source
+      Whitelist_key sourcetype
+    [OUTPUT]
+      Name splunk
+      Match *
+      Host ${SPLUNK_HOST}
+      Port ${SPLUNK_PORT}
+      Splunk_Token ${SPLUNK_TOKEN}
+      Splunk_Send_Raw On
+      tls On
+    # [OUTPUT]
+    #   Name stdout
+    #   Match *
+    #   Format json_lines
+  parsers.conf: |
+    [PARSER]
+      # Parser for Docker container logs
+      # Docker logs are in JSON format. Each line is a JSON object which has
+      # the following keys:
+      # - time: ISO-8601 combined date and time representation
+      # - stream: stdout or stderr
+      # - log: Full log line from container process
+      # https://docs.fluentbit.io/manual/parser/json
+      Name docker
+      Format json
+      Time_Key time
+      Time_Format %Y-%m-%dT%H:%M:%S.%L
+      Time_Keep On
+      Decode_Field_As json log try_next
+      Decode_Field_As escaped_utf8 log
+    [PARSER]
+      # Parser for CRI container logs
+      # Note: As of December 2019, CRI support is still experimental!
+      # The CRI log format is underdocumented as of November 2019. This parser
+      # is reverse engineered from Kubernetes source code. CRI logs are
+      # unstructured and (appear to) follow this format:
+      # <time> <stream> <tags> <log>
+      # - time: ISO-8601 combined date and time representation
+      # - stream: stdout or stderr
+      # - tags: A colon-delimited list of log tags. Tags are a simple list of
+      #   strings (i.e. not key value pairs) and there does not appear to be a
+      #   documented validator for the tags. Every log has at least one tag,
+      #   which is a single capital letter F, P or E:
+      #   - F: Log is a full line.
+      #   - P: Log is a partial line and continues on the next line of the
+      #     stream.
+      #   - E: Log is the ending line of a series of partials.
+      #  - log: Full or partial log line from the container process.
+      # https://github.com/kubernetes/kubernetes/blob/3a1c9449a956b6026f075fa3134ff92f7d55f812/pkg/kubelet/apis/cri/v1alpha1/runtime/constants.go#L39-L55
+      # https://github.com/kubernetes/kubernetes/blob/v1.15.5/pkg/kubelet/kuberuntime/logs/logs.go#L129-L173
+      # https://docs.fluentbit.io/manual/parser/regular_expression
+      Name cri-o
+      Format regex
+      # This uses Rubular regex to extract the time, stream, tags and log fields.
+      # A Rubuluar sandbox is available at https://rubular.com
+      Regex ^(?<time>.+) (?<stream>stdout|stderr) (?<tags>[\S:]+) (?<log>.*)$
+      Time_Key time
+      Time_Format %Y-%m-%dT%H:%M:%S.%L
+      Time_Keep On
+{{- end }}

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -55,3 +55,79 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+{{- if .Values.logForward.create }}
+      - name: {{ .Values.splunk.fluentBit.name }}
+        image: "{{ .Values.splunk.fluentBit.image.repository }}:{{ .Values.splunk.fluentBit.image.tag }}"
+        imagePullPolicy: {{ .Values.splunk.fluentBit.image.pullPolicy }}
+        {{- if .Values.splunk.fluentBit.resources }}
+        resources:
+{{ toYaml .Values.splunk.fluentBit.resources | indent 10 }}
+        {{- end }}
+        ports:
+          - containerPort: {{ .Values.splunk.fluentBit.port }} # metrics endpoint is ${POD_IP}:2020/api/v1/metrics/prometheus
+        volumeMounts:
+          - name: fluent-bit-config
+            mountPath: /fluent-bit/etc
+          - name: logging-volume
+            mountPath: /logging-volume
+          - name: fluent-data
+            mountPath: /var/fluent-bit
+        env:
+        - name: SPLUNK_HOST
+          value: "{{ .Values.splunk.host }}"
+        - name: SPLUNK_PORT
+          value: "{{ .Values.splunk.port }}"
+        - name: SPLUNK_INDEX
+          value: "{{ .Values.splunk.index }}"
+        - name: SPLUNK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.splunk.token }}
+              key: token
+        - name: SPLUNK_SOURCE
+          value: {{ .Values.splunk.source }}
+        - name: POD_UID_FLUENT_BIT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: SPLUNK_SOURCETYPE
+          value: {{ .Values.splunk.sourceType }}
+        - name: CONTAINER_RUNTIME
+          value: {{ .Values.splunk.containerRuntime }}
+      volumes:
+        - name: fluent-bit-config
+          configMap:
+            name: {{ .Values.splunk.fluentBit.name }}-configmap
+        - name: logging-volume
+          emptyDir: {}
+        - name: fluent-data
+          emptyDir: {}
+      imagePullSecrets:
+{{- range (default .Values.global.imagePullSecrets .Values.splunk.fluentBit.image.imagePullSecrets ) }}
+      - name: {{ . }}
+{{- end }}
+{{- range (default .Values.global.imagePullSecrets .Values.serviceAccount.imagePullSecrets ) }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   create: true
   name: zookeeper-operator
   ## Optionally specify an array of imagePullSecrets. Will override the global parameter if set
-  # imagePullSecrets:
+  ## imagePullSecrets:
 
 ## Whether to create the CRD.
 crd:
@@ -47,3 +47,35 @@ affinity: {}
 tolerations: []
 # Pod annotations
 annotations: {}
+
+## Whether to create the LogForwarding.
+## In this usecase, we are using splunk as destination for logs.
+logForward:
+  create: true
+
+## fluent-bit image details and whether to enable it or not.
+## splunk host,index details.
+splunk:
+  host: "splunk-hec-ext.adobe.net"
+  source: "zookeeper-operator"
+  index: "plat_app_preprod"
+  containerRuntime: "cri-o"
+  sourceType: "pod"
+  port: 443
+  token: "splunk-token"
+  fluentBit:
+    name: "fluent-bit"
+    resources:
+      limits:
+        cpu: "250m"
+        memory: "512Mi"
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
+    port: 2020
+    image:
+      repository: docker-k8s-infrastructure-public-release.dr-uw2.adobeitc.com/ethos/ethos-fluent-bit
+      tag: 1.5.6-debug
+      pullPolicy: IfNotPresent
+      imagePullSecrets:
+        - artifactory-registry-key


### PR DESCRIPTION
### Change log description

fluent-bit sidecar enabled for operator logs.
Using fluent-bit, pushing logs to Splunk server.

### Purpose of the change

Send Ethos K8s Operators (ZK & Kafka) logs to Splunk

### What the code does

Operator deployment updated to watch and pull the operator logs and pushed to the Splunk server.
Splunk and fluid-bit are configurable using the Values.

splunk:
  host: {}
  source: "zookeeper-operator"
  index: {}
  containerRuntime: "cri-o"
  sourceType: "pod"
  port: 443
  token: {}
  fluentBit:
    name: "fluent-bit"
    resources:
      limits:
        cpu: "250m"
        memory: "512Mi"
      requests:
        cpu: "50m"
        memory: "128Mi"
    port: 2020
    image:
      repository: {}
      tag: {}
      pullPolicy: IfNotPresent
      imagePullSecrets: {}


