### PR TITLE
Option to override/define templates for additional sidecars and volumes

### DIFF
--- a/charts/zookeeper-operator/templates/_helpers.tpl
+++ b/charts/zookeeper-operator/templates/_helpers.tpl
@@ -35,3 +35,18 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end -}}
+
+
+{{/*
+Default sidecar template
+*/}}
+{{- define "chart.additionalSidecars"}}
+{{ toYaml .Values.additionalSidecars }}
+{{- end}}
+
+{{/*
+Default volume template
+*/}}
+{{- define "chart.additionalVolumes"}}
+{{ toYaml .Values.additionalVolumes }}
+{{- end}}

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- if .Values.additionalVolumes }}
       volumes:
-{{ toYaml .Values.additionalVolumes | indent 6 }}
+{{- include "chart.additionalVolumes" . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ template "zookeeper-operator.fullname" . }}
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
       {{- if .Values.additionalSidecars }}
-{{ toYaml .Values.additionalSidecars | indent 6 }}
+{{- include "chart.additionalSidecars" . | indent 6 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
### Change log description

Wrapped `additionalSidecars` and `additionalVolumes` inside named templates. 

### Purpose of the change

Allows for defining templates by extending the zookeeper-operator chart and overwriting `chart.*`
