### PR TITLE
Adding SEED_PORT to have a port override alongside the existing SEED_NODE.

### DIFF
--- a/docker/bin/zookeeperFunctions.sh
+++ b/docker/bin/zookeeperFunctions.sh
@@ -29,7 +29,12 @@ function zkConnectionString() {
     set -e
     echo "localhost:${CLIENT_PORT}"
   else
+    if [ -z "${SEED_PORT}" ]; then
+      PORT=${CLIENT_PORT}
+    else
+      PORT=${SEED_PORT}
+    fi
     set -e
-    echo "${CLIENT_HOST}:${CLIENT_PORT}"
+    echo "${CLIENT_HOST}:${PORT}"
   fi
 }

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -27,7 +27,6 @@ OFFSET=${OFFSET:-1}
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
 
-echo "TESTING READINESS NOW"
 OK=$(echo ruok | socat stdio tcp:localhost:$CLIENT_PORT)
 
 # Check to see if zookeeper service answers
@@ -39,7 +38,6 @@ if [[ "$OK" == "imok" ]]; then
     echo "There is no active ensemble, skipping readiness probe..."
     exit 0
   else
-    echo "ACTIVE ENSEMBLE, TESTING READINESS"
     set -e
     # An ensemble exists, check to see if this node is already a member.
     # Check to see if zookeeper service for this node is a participant

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -26,8 +26,8 @@ OFFSET=${OFFSET:-1}
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
-CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
 
+echo "TESTING READINESS NOW"
 OK=$(echo ruok | socat stdio tcp:localhost:$CLIENT_PORT)
 
 # Check to see if zookeeper service answers
@@ -39,6 +39,7 @@ if [[ "$OK" == "imok" ]]; then
     echo "There is no active ensemble, skipping readiness probe..."
     exit 0
   else
+    echo "ACTIVE ENSEMBLE, TESTING READINESS"
     set -e
     # An ensemble exists, check to see if this node is already a member.
     # Check to see if zookeeper service for this node is a participant
@@ -88,12 +89,18 @@ if [[ "$OK" == "imok" ]]; then
       exit 0
     elif [[ "$ROLE" == "observer" ]]; then
       echo "Zookeeper service is ready to be upgraded from observer to participant."
-      ROLE=participant
+      SSL_OPTIONS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true"
       ZKURL=$(zkConnectionString)
+      ROLE=participant
       ZKCONFIG=$(zkConfig $OUTSIDE_NAME)
-      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/libs/zu.jar remove $ZKURL $MYID
+      if [[ "$ZKURL" =~ :2182$ ]]; then
+        ZK_OPTIONS="$SSL_OPTIONS"
+      else
+        ZK_OPTIONS=""
+      fi
+      java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar remove $ZKURL $MYID 
       sleep 1
-      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/libs/zu.jar add $ZKURL $MYID $ZKCONFIG
+      java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar add $ZKURL $MYID $ZKCONFIG
       exit 0
     else
       echo "Something has gone wrong. Unable to determine zookeeper role."

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -26,7 +26,7 @@ OFFSET=${OFFSET:-1}
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
-
+CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
 
 OK=$(echo ruok | socat stdio tcp:localhost:$CLIENT_PORT)
 

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -158,7 +158,13 @@ if [[ "$REGISTER_NODE" == true ]]; then
     ZKCONFIG=$(zkConfig $OUTSIDE_NAME)
     set -e
     echo Registering node and writing local configuration to disk.
-    java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
+    SSL_OPTIONS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true"
+    if [ "$ZKURL" =~ ":2182$" ]; then
+      ZK_OPTIONS="$SSL_OPTIONS"
+    else
+      ZK_OPTIONS=""
+    fi
+    java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
     set +e
 fi
 

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -127,11 +127,9 @@ fi
 
 if [[ "$ACTIVE_ENSEMBLE" == false ]]; then
   # This is the first node being added to the cluster or headless service not yet available
-  echo "Active_Ensemble = $ACTIVE_ENSEMBLE, register_node false" #REMOVE
   REGISTER_NODE=false
 else
   # An ensemble exists, check to see if this node is already a member.
-  echo "ONDISK_MYID_CONFIG = $ONDISK_MYID_CONFIG, ONDISK_DYN_CONFIG = $ONDISK_DYN_CONFIG" #REMOVE
   if [[ "$ONDISK_MYID_CONFIG" == false || "$ONDISK_DYN_CONFIG" == false ]]; then
     REGISTER_NODE=true
   else

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -42,6 +42,7 @@ MYID=$(($ORD+$OFFSET))
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
 CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
+echo "CLIENT_HOST = $CLIENT_HOST, CLIENT_PORT = $CLIENT_PORT, SEED_PORT = $SEED_PORT" # REMOVE
 
 
 # use FQDN_TEMPLATE to create an OUTSIDE_NAME that is going to be used to establish quorum election
@@ -66,6 +67,7 @@ ONDISK_MYID_CONFIG=false
 ONDISK_DYN_CONFIG=false
 
 # Check validity of on-disk configuration
+echo "EXISTING_ID = $EXISTING_ID, MYID = $MYID" # REMOVE
 if [ -f $MYID_FILE ]; then
   EXISTING_ID="`cat $DATA_DIR/myid`"
   if [[ "$EXISTING_ID" == "$MYID" && -f $STATIC_CONFIG ]]; then
@@ -74,7 +76,7 @@ if [ -f $MYID_FILE ]; then
   fi
 fi
 
-if [ -f $DYNCONFIG ]; then
+if [ -f $DYNCONFIG ] && [ -z $SEED_NODE ]; then
   ONDISK_DYN_CONFIG=true
 fi
 
@@ -128,15 +130,21 @@ fi
 
 if [[ "$ACTIVE_ENSEMBLE" == false ]]; then
   # This is the first node being added to the cluster or headless service not yet available
+  echo "Active_Ensemble = $ACTIVE_ENSEMBLE, register_node false" #REMOVE
   REGISTER_NODE=false
 else
   # An ensemble exists, check to see if this node is already a member.
+  echo "ONDISK_MYID_CONFIG = $ONDISK_MYID_CONFIG, ONDISK_DYN_CONFIG = $ONDISK_DYN_CONFIG" #REMOVE
   if [[ "$ONDISK_MYID_CONFIG" == false || "$ONDISK_DYN_CONFIG" == false ]]; then
     REGISTER_NODE=true
   else
     REGISTER_NODE=false
   fi
 fi
+
+echo "======= WRITE CONFIG DEBUG ======" # REMOVE
+echo "write configuration = $WRITE_CONFIGURATION" # REMOVE
+echo "myID = $MYID, SEED_NODE = $SEED_NODE, OFFSET = $OFFSET" # REMOVE
 
 if [[ "$WRITE_CONFIGURATION" == true ]]; then
   echo "Writing myid: $MYID to: $MYID_FILE."
@@ -152,19 +160,26 @@ if [[ "$WRITE_CONFIGURATION" == true ]]; then
   fi
 fi
 
+echo "DYNAMIC CONFIG = " # REMOVE
+cat $DYNCONFIG # REMOVE
+
+    echo "REGISTER NODE BEFORE SCRIPT = $REGISTER_NODE" # REMOVE
 if [[ "$REGISTER_NODE" == true ]]; then
+    echo "BEGIN SSL CONNECTION DEBUG" # REMOVE
+    echo "register_node " + $REGISTER_NODE # REMOVE
     ROLE=observer
     ZKURL=$(zkConnectionString)
     ZKCONFIG=$(zkConfig $OUTSIDE_NAME)
     set -e
+    echo "ZKURL= " + $ZKURL # REMOVE
     echo Registering node and writing local configuration to disk.
     SSL_OPTIONS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true"
-    if [ "$ZKURL" =~ ":2182$" ]; then
+    if [[ "$ZKURL" =~ :2182$ ]]; then
       ZK_OPTIONS="$SSL_OPTIONS"
     else
       ZK_OPTIONS=""
     fi
-    java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
+    java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG 
     set +e
 fi
 
@@ -183,6 +198,10 @@ cp -f /conf/log4j-quiet.properties $ZOOCFGDIR
 cp -f /conf/env.sh $ZOOCFGDIR
 
 if [ -f $DYNCONFIG ]; then
+  echo "DYNAMIC CONFIG = " # REMOVE
+  cat $DYNCONFIG # REMOVE
+  echo "STATIC CONFIG = " # REMOVE
+  cat $STATIC_CONFIG # REMOVE
   # Node registered, start server
   echo Starting zookeeper service
   zkServer.sh --config $ZOOCFGDIR start-foreground

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -41,8 +41,6 @@ MYID=$(($ORD+$OFFSET))
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
-CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
-echo "CLIENT_HOST = $CLIENT_HOST, CLIENT_PORT = $CLIENT_PORT, SEED_PORT = $SEED_PORT" # REMOVE
 
 
 # use FQDN_TEMPLATE to create an OUTSIDE_NAME that is going to be used to establish quorum election
@@ -67,7 +65,6 @@ ONDISK_MYID_CONFIG=false
 ONDISK_DYN_CONFIG=false
 
 # Check validity of on-disk configuration
-echo "EXISTING_ID = $EXISTING_ID, MYID = $MYID" # REMOVE
 if [ -f $MYID_FILE ]; then
   EXISTING_ID="`cat $DATA_DIR/myid`"
   if [[ "$EXISTING_ID" == "$MYID" && -f $STATIC_CONFIG ]]; then
@@ -142,9 +139,6 @@ else
   fi
 fi
 
-echo "======= WRITE CONFIG DEBUG ======" # REMOVE
-echo "write configuration = $WRITE_CONFIGURATION" # REMOVE
-echo "myID = $MYID, SEED_NODE = $SEED_NODE, OFFSET = $OFFSET" # REMOVE
 
 if [[ "$WRITE_CONFIGURATION" == true ]]; then
   echo "Writing myid: $MYID to: $MYID_FILE."
@@ -160,18 +154,12 @@ if [[ "$WRITE_CONFIGURATION" == true ]]; then
   fi
 fi
 
-echo "DYNAMIC CONFIG = " # REMOVE
-cat $DYNCONFIG # REMOVE
 
-    echo "REGISTER NODE BEFORE SCRIPT = $REGISTER_NODE" # REMOVE
 if [[ "$REGISTER_NODE" == true ]]; then
-    echo "BEGIN SSL CONNECTION DEBUG" # REMOVE
-    echo "register_node " + $REGISTER_NODE # REMOVE
     ROLE=observer
     ZKURL=$(zkConnectionString)
     ZKCONFIG=$(zkConfig $OUTSIDE_NAME)
     set -e
-    echo "ZKURL= " + $ZKURL # REMOVE
     echo Registering node and writing local configuration to disk.
     SSL_OPTIONS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true"
     if [[ "$ZKURL" =~ :2182$ ]]; then
@@ -198,10 +186,6 @@ cp -f /conf/log4j-quiet.properties $ZOOCFGDIR
 cp -f /conf/env.sh $ZOOCFGDIR
 
 if [ -f $DYNCONFIG ]; then
-  echo "DYNAMIC CONFIG = " # REMOVE
-  cat $DYNCONFIG # REMOVE
-  echo "STATIC CONFIG = " # REMOVE
-  cat $STATIC_CONFIG # REMOVE
   # Node registered, start server
   echo Starting zookeeper service
   zkServer.sh --config $ZOOCFGDIR start-foreground

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -41,6 +41,7 @@ MYID=$(($ORD+$OFFSET))
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
+CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
 
 
 # use FQDN_TEMPLATE to create an OUTSIDE_NAME that is going to be used to establish quorum election

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -21,7 +21,6 @@ LOG4J_CONF=/conf/log4j-quiet.properties
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
-CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
 
 # used when zkid starts from value grater then 1, default 1
 OFFSET=${OFFSET:-1}

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -21,6 +21,7 @@ LOG4J_CONF=/conf/log4j-quiet.properties
 # use SEED_NODE to bootstrap the current zookeeper cluster, else default to local cluster
 # CLIENT_HOST is used in zkConnectionString function already to create zkURL
 CLIENT_HOST=${SEED_NODE:-$CLIENT_HOST}
+CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}
 
 # used when zkid starts from value grater then 1, default 1
 OFFSET=${OFFSET:-1}

--- a/docker/zu/src/main/java/io/pravega/zookeeper/Main.kt
+++ b/docker/zu/src/main/java/io/pravega/zookeeper/Main.kt
@@ -50,6 +50,7 @@ fun runSync(args: Array<String>, suppressOutput: Boolean = false): String {
       if (! suppressOutput) {
           print(clusterSize)
       }
+      zk.close()
       clusterSize
     } catch (e: Exception) {
       System.err.println("Error performing zookeeper sync operation:")
@@ -71,6 +72,7 @@ fun runGetAll(args: Array<String>, suppressOutput: Boolean = false): String {
         if (! suppressOutput) {
             print(zkCfg)
         }
+        zk.close()
         zkCfg
     } catch (e: Exception) {
         System.err.println("Error getting server config")
@@ -129,6 +131,7 @@ fun reconfigure(zkUrl: String, joining: String?, leaving: String?, outputFile: S
         } else {
             File(outputFile).bufferedWriter().use {it.write(cfgStr + "\n")}
         }
+        zk.close()
     } catch (e: Exception) {
         System.err.println("Error performing zookeeper reconfiguration:")
         e.printStackTrace(System.err)


### PR DESCRIPTION


### Change log description

Adding the capability of a pod env named SEED_PORT to override the CLIENT_PORT during startup and teardown zookeeper scripts. Currently only CLIENT_HOST has an override (SEED_NODE) which defaults to port 2181. 


### What the code does

adding
`CLIENT_PORT=${SEED_PORT:-$CLIENT_PORT}`
to places where CLIENT_HOST is being overwritten by SEED_NODE

