### PR TITLE
Run the ZU utility over TLS

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -157,7 +157,13 @@ if [[ "$REGISTER_NODE" == true ]]; then
     ZKCONFIG=$(zkConfig $OUTSIDE_NAME)
     set -e
     echo Registering node and writing local configuration to disk.
-    java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
+    SSL_OPTIONS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true"
+    if [ "$ZKURL" =~ ":2182$" ]; then
+      ZK_OPTIONS="$SSL_OPTIONS"
+    else
+      ZK_OPTIONS=""
+    fi
+    java -Dlog4j.configuration=file:"$LOG4J_CONF" $ZK_OPTIONS -jar /opt/libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
     set +e
 fi
 

--- a/docker/zu/src/main/java/io/pravega/zookeeper/Main.kt
+++ b/docker/zu/src/main/java/io/pravega/zookeeper/Main.kt
@@ -50,6 +50,7 @@ fun runSync(args: Array<String>, suppressOutput: Boolean = false): String {
       if (! suppressOutput) {
           print(clusterSize)
       }
+      zk.close()
       clusterSize
     } catch (e: Exception) {
       System.err.println("Error performing zookeeper sync operation:")
@@ -71,6 +72,7 @@ fun runGetAll(args: Array<String>, suppressOutput: Boolean = false): String {
         if (! suppressOutput) {
             print(zkCfg)
         }
+        zk.close()
         zkCfg
     } catch (e: Exception) {
         System.err.println("Error getting server config")
@@ -129,6 +131,7 @@ fun reconfigure(zkUrl: String, joining: String?, leaving: String?, outputFile: S
         } else {
             File(outputFile).bufferedWriter().use {it.write(cfgStr + "\n")}
         }
+        zk.close()
     } catch (e: Exception) {
         System.err.println("Error performing zookeeper reconfiguration:")
         e.printStackTrace(System.err)


### PR DESCRIPTION
Run the ZU utility over TLS. Tested with:
```
java -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -jar /zu.jar add kafka-1-az1-or2-1-secure.dev.pipeline.adobedc.net:2182 121 "localhost:2888:3888:observer;0.0.0.0:2181"

java -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -jar /zu.jar get-all kafka-1-az1-or2-1-secure.dev.pipeline.adobedc.net:2182
```