### PR TITLE
Fix test related to default image version

### DIFF
--- a/api/v1beta1/zookeepercluster_types_test.go
+++ b/api/v1beta1/zookeepercluster_types_test.go
@@ -79,7 +79,8 @@ var _ = Describe("ZookeeperCluster Types", func() {
 			})
 
 			It("Checking tostring() function", func() {
-				Ω(z.Spec.Image.ToString()).To(Equal("pravega/zookeeper:0.2.15"))
+				expected := fmt.Sprintf("%s:%s", v1beta1.DefaultZkContainerRepository, v1beta1.DefaultZkContainerVersion)
+				Ω(z.Spec.Image.ToString()).To(Equal(expected))
 			})
 
 		})


### PR DESCRIPTION
```
------------------------------
• Failure [0.001 seconds]
ZookeeperCluster Types
/Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:26
  #WithDefaults
  /Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:36
    Image
    /Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:62
      Checking tostring() function [It]
      /Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:81

      Expected
          <string>: ghcr.io/adobe/zookeeper-operator/zookeeper:3.8.4-0.2.15-adobe-20250923
      to equal
          <string>: pravega/zookeeper:0.2.15

      /Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:82
------------------------------
•••••••••••••••••••••••••••••••••

Summarizing 1 Failure:

[Fail] ZookeeperCluster Types #WithDefaults Image [It] Checking tostring() function 
/Users/dobre/work/zookeeper-operator/api/v1beta1/zookeepercluster_types_test.go:82
```