### PR TITLE
Fix ARM builds in CI; add missing builds in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG DOCKER_REGISTRY
 ARG DISTROLESS_DOCKER_REGISTRY
 ARG ALPINE_VERSION=3.22
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}golang:1.25-alpine${ALPINE_VERSION} AS go-builder
+FROM --platform=${BUILDPLATFORM} ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}golang:1.25-alpine${ALPINE_VERSION} AS go-builder
 
 ARG PROJECT_NAME=zookeeper-operator
 ARG REPO_PATH=github.com/adobe/$PROJECT_NAME
@@ -25,8 +25,10 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 
-# Build
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /src/${PROJECT_NAME} \
+#Build
+ARG TARGETOS
+ARG TARGETARCH
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} CGO_ENABLED=0 go build -o /src/${PROJECT_NAME} \
     -ldflags "-X ${REPO_PATH}/pkg/version.Version=${VERSION} -X ${REPO_PATH}/pkg/version.GitSHA=${GIT_SHA}" main.go
 
 FROM ${DISTROLESS_DOCKER_REGISTRY:-gcr.io/}distroless/static-debian11:nonroot AS final

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,12 @@ build-go:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 		-ldflags "-X github.com/$(REPO)/pkg/version.Version=$(VERSION) -X github.com/$(REPO)/pkg/version.GitSHA=$(GIT_SHA)" \
 		-o bin/$(EXPORTER_NAME)-linux-amd64 cmd/exporter/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+		-ldflags "-X github.com/$(REPO)/pkg/version.Version=$(VERSION) -X github.com/$(REPO)/pkg/version.GitSHA=$(GIT_SHA)" \
+		-o bin/$(PROJECT_NAME)-linux-arm64 main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+		-ldflags "-X github.com/$(REPO)/pkg/version.Version=$(VERSION) -X github.com/$(REPO)/pkg/version.GitSHA=$(GIT_SHA)" \
+		-o bin/$(EXPORTER_NAME)-linux-arm64 cmd/exporter/main.go
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build \
 		-ldflags "-X github.com/$(REPO)/pkg/version.Version=$(VERSION) -X github.com/$(REPO)/pkg/version.GitSHA=$(GIT_SHA)" \
 		-o bin/$(PROJECT_NAME)-darwin-amd64 main.go
@@ -143,13 +149,11 @@ build-image:
 PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name zookeeper-builder
 	docker buildx use zookeeper-builder
-	docker buildx build --push --platform=$(PLATFORMS) --tag $(IMG) -f Dockerfile.cross .
+	docker buildx build --push --platform=$(PLATFORMS) --tag $(IMG) \
+		--build-arg VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) -f Dockerfile .
 	- docker buildx rm zookeeper-builder
-	rm Dockerfile.cross
 
 build-zk-image:
 


### PR DESCRIPTION
### Change log description

1) Parameterize TARGETOS and TARGETARCH in Dockerfile
2) Add missing builds to Makefile
3) Pin go-builder to the build host's native platform via --platform=${BUILDPLATFORM} (native compile, no QEMU)
4) Drop Dockerfile.cross sed hack; no longer needed due to (3)

### Purpose of the change

The build step hardcoded `GOARCH=amd64`, ignoring the target platform, which resulted in amd64 ZK Operator binaries being compiled in the published arm64 images. The Build IDs for the amd64 and arm64 binaries of the latest version are both `80bb39507633d95013178b95c542498d14283017`, and machine type is `x86-64`. The Makefile also skips arm64 builds for ZK Operator and Exporter.

### What the code does

- Fix arm64 image builds so the arm64 image contains a genuine arm64 binary
- Add missing arm64 builds to the Makefile

### How to verify it

Build the arm64 image and inspect the binary. Its architecture should match the target platform (aarch64), not x86-64:

```zsh
docker buildx build --platform linux/arm64 -t zkop:arm64 --load .
cid=$(docker create zkop:arm64)
docker cp "$cid:/usr/local/bin/zookeeper-operator" ./zk.bin && docker rm "$cid"
file ./zk.bin   # expect: ELF 64-bit … ARM aarch64 (was: x86-64)
```

Running the above on master returns x86-64.
